### PR TITLE
DOC: correct link

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,7 +10,7 @@ and used by many remote users. This page provides information for those who
 wish to use a pre-existing Binder deployment (e.g., ``mybinder.org``).
 
 If you'd like to create and administer your own Binder deployment, see the
-`BinderHub documentation <binderhub.readthedocs.org>`_. The BinderHub
+`BinderHub documentation <http://binderhub.readthedocs.io>`_. The BinderHub
 documentation guides you through creating a cluster, deploying BinderHub, and
 administering a BinderHub deployment.
 


### PR DESCRIPTION
Currently the link was not working because it was interpreted as a relative link.