### PR TITLE
Add issue template with pointers to other repositories

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,11 +1,13 @@
 <!--
 Welcome!
 
-Help us stay on top of issues by submitting to the right repository. For
+Help us stay on top of issues by submitting them to the right repository. For
 issues related to:
-* ... the particulars of the https://mybinder.org site or deployment: https://github.com/jupyterhub/mybinder.org-deploy/issues/new
-* ... binderhub, the software behind mybinder.org, in general: https://github.com/jupyterhub/binderhub/issues/new
-* ... the repo2docker tool that builds containers from repositories: https://github.com/jupyter/repo2docker/issues/new
+* ... building images: https://github.com/jupyterhub/binder/new
+* ... the https://mybinder.org site not working or misbehaving: https://github.com/jupyterhub/mybinder.org-deploy/issues/new
+* ... the software powering all this (binderhub) in general: https://github.com/jupyterhub/binderhub/issues/new
 
-Thank you for contributing.
+If you aren't sure where to go use https://github.com/jupyterhub/binder/new.
+
+Thank you for being awesome!
 -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+<!--
+Welcome!
+
+Help us stay on top of issues by submitting to the right repository. For
+issues related to:
+* ... the particulars of the https://mybinder.org site or deployment: https://github.com/jupyterhub/mybinder.org-deploy/issues/new
+* ... binderhub, the software behind mybinder.org, in general: https://github.com/jupyterhub/binderhub/issues/new
+* ... the repo2docker tool that builds containers from repositories: https://github.com/jupyter/repo2docker/issues/new
+
+Thank you for contributing.
+-->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,8 +3,8 @@ Welcome!
 
 Help us stay on top of issues by submitting them to the right repository. For
 issues related to:
-* ... building images: https://github.com/jupyterhub/binder/new
-* ... the https://mybinder.org site not working or misbehaving: https://github.com/jupyterhub/mybinder.org-deploy/issues/new
+* ... "my repository isn't building properly": https://github.com/jupyterhub/binder/new
+* ... https://mybinder.org site downtime or inaccessible pages: https://github.com/jupyterhub/mybinder.org-deploy/issues/new
 * ... the software powering all this (binderhub) in general: https://github.com/jupyterhub/binderhub/issues/new
 
 If you aren't sure where to go use https://github.com/jupyterhub/binder/new.


### PR DESCRIPTION
Help new users (as well as experienced ones) with filing issues on the "right" repository. If we like this I'd propose to add this template to all of the mentioned repos.