### PR TITLE
adding a first pass at more info

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -29,3 +29,4 @@ Site contents
    reproducibility
    sample_repos
    faq
+   more-info

--- a/doc/more-info.rst
+++ b/doc/more-info.rst
@@ -1,0 +1,21 @@
+More information about Binder
+=============================
+
+This is a place to aggregate information, goings-on,
+case-studies, blog posts, etc about the Binder community.
+If you'd like to add something to this page, feel free to
+`open an issue <https://github.com/jupyterhub/binder/issues>`_!
+
+Blog posts
+----------
+
+* `Four steps to Binder in five minutes <http://ivory.idyll.org/blog/2017-four-steps-five-minutes-binder.html>`_
+  by `Titus Brown <https://twitter.com/ctitusbrown>`_.
+* `Binder: an awesome tool for hosting Jupyter Notebooks <https://jvns.ca/blog/2017/11/12/binder--an-awesome-tool-for-hosting-jupyter-notebooks/>`_
+  by `Julia Evans <https://jvns.ca/>`_.
+
+Tools
+-----
+
+* `Open in Binder <https://carreau.github.io/posts/32-open-with-binder-chrome.html>`_, a Google Chrome extension
+  by `Matthias Bussonier <https://carreau.github.io>`_.


### PR DESCRIPTION
Per conversations with @ctb and @willingc , this adds a "more info" section where we can link to community posts, information that doesn't fit clearly into the docs, etc. Let me know if I should add other links etc!