### PR TITLE
adding binder folder text

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -60,6 +60,25 @@ A Binder is a GitHub repository that has been outfitted with the appropriate
 `build files <http://repo2docker.readthedocs.io/en/latest/samples.html>`_ so
 that its content can be connected with a BinderHub instance.
 
+Can I put my configuration files outside the root of my repository?
+-------------------------------------------------------------------
+
+Yes! If you don't want your configuration files inside of your repository
+root (e.g., because you have multiple ``requirements.txt`` files), you can
+also place Binder configuration files in a folder called ``binder`` that is
+in the root of your repository. E.g.::
+
+  myproject/
+  ├── binder
+  │   └── requirements.txt
+  ├── environment.yml
+  ├── myfile.py
+  └── requirements.txt
+
+In this case, only the ``requirments.txt`` file inside ``binder/`` will be
+used to build your environment. All other configuration files outside of the
+``binder/`` folder will be ignored.
+
 What can I do if ``mybinder.org`` does not meet my needs?
 ---------------------------------------------------------
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -63,21 +63,12 @@ that its content can be connected with a BinderHub instance.
 Can I put my configuration files outside the root of my repository?
 -------------------------------------------------------------------
 
-Yes! If you don't want your configuration files inside of your repository
-root (e.g., because you have multiple ``requirements.txt`` files), you can
-also place Binder configuration files in a folder called ``binder`` that is
-in the root of your repository. E.g.::
-
-  myproject/
-  ├── binder
-  │   └── requirements.txt
-  ├── environment.yml
-  ├── myfile.py
-  └── requirements.txt
-
-In this case, only the ``requirments.txt`` file inside ``binder/`` will be
-used to build your environment. All other configuration files outside of the
-``binder/`` folder will be ignored.
+Yes! Configuration files may be placed in the root of your repository or
+in a ``binder/`` folder in the root of your repository (i.e. ``myproject/binder/``).
+If a ``binder/`` folder is used, Binder will only read configuration files
+from that location (i.e. ``myproject/binder/requirements.txt``) and will
+ignore those in the repository's root (``myproject/environment.yml`` and
+``myproject/requirements.txt``).
 
 What can I do if ``mybinder.org`` does not meet my needs?
 ---------------------------------------------------------

--- a/doc/using.rst
+++ b/doc/using.rst
@@ -17,12 +17,13 @@ your Binder repository should contain at least:
 
 * The code you want users to run. This might be a collection of Jupyter
   notebooks or scripts.
-* One (or many) text files that specify the requirements of your code.
-  For a complete list, see :ref:`config-files`.
-
-Configuration text files should be either in the **root** of your
-repository, or in a folder in the root of the repository that is called
-``binder``. E.g., ``myrepo/binder/requirements.txt``.
+* Configuration files (one or more text files) that specify the requirements
+  for building your project's code. For a complete list of supported files,
+  see :ref:`config-files`. Configuration files may be placed in the root of
+  your repository or in a ``binder/`` folder in the repository's root
+  (i.e. ``myproject/binder/``). If a ``binder/`` folder is used, Binder will
+  only read configuration files from that location and will ignore those in
+  the repository's root.
 
 .. tip::
 

--- a/doc/using.rst
+++ b/doc/using.rst
@@ -20,6 +20,10 @@ your Binder repository should contain at least:
 * One (or many) text files that specify the requirements of your code.
   For a complete list, see :ref:`config-files`.
 
+Configuration text files should be either in the **root** of your
+repository, or in a folder in the root of the repository that is called
+``binder``. E.g., ``myrepo/binder/requirements.txt``.
+
 .. tip::
 
    For a list of sample repositories for use with Binder, see the


### PR DESCRIPTION
This adds more language explaining the usage of the `binder/` folder, as a number of people keep asking questions about whether this is possible. (e.g. https://github.com/jupyterhub/binderhub/issues/381)

cc @betatim 