### PR TITLE
adding a getting-started binder link

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -1,6 +1,12 @@
 Welcome to the Binder documentation
 ===================================
 
+For a quick introduction to Binder, and a demonstration of how you can
+make a Binder-ready repository, click the Binder link below:
+
+.. image:: https://mybinder.org/badge.svg
+   :target: https://mybinder.org/v2/gh/binder-examples/zero-to-binder/master?filepath=intro-to-binder.ipynb
+
 What can I do with Binder?
 --------------------------
 


### PR DESCRIPTION
I adapted a Data Carpentry "Intro to Binder" notebook for the Binder documentation - the idea is to get a quick "how to create a Binder repository" demonstration that's also kind of fun.

I've added that repository to binder-examples: https://github.com/binder-examples/zero-to-binder 

This PR adds a link to that Binder in our `introduction` page. Here's the Binder link:

https://mybinder.org/v2/gh/binder-examples/zero-to-binder/master?filepath=intro-to-binder.ipynb

What do y'all think?