### PR TITLE
fixing abuse link

### DIFF
--- a/doc/user-guidelines.rst
+++ b/doc/user-guidelines.rst
@@ -42,4 +42,4 @@ Reporting Abuse
 ---------------
 
 If you'd like to report any abuse of the ``mybinder.org`` service, please
-`click here to send an abuse report <mailto:binder-team@googlegroups.com?subject=[ABUSE]<your-message-here>`_.
+`click here to send an abuse report <mailto:binder-team@googlegroups.com?subject=[ABUSE] your-message-here>`_.


### PR DESCRIPTION
The abuse link was broken because it had `<` in it, this fixes that