### PR TITLE
adding reliability metrics page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,6 +17,12 @@ administering a BinderHub deployment.
 See the `Binder Examples <https://github.com/binder-examples>`_ GitHub
 organization for sample Binder repositories demonstrating its functionality.
 
+.. note::
+
+   Binder is a research pilot, whose main goal is to understand usage patterns
+   and workloads for future evolution and development. It is not a service that
+   can be relied on for critical operations.
+
 Using Binder
 ------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -52,4 +52,5 @@ as resources for more information.
    dockerfile
    reproducibility
    faq
+   reliability
    more-info

--- a/doc/reliability.rst
+++ b/doc/reliability.rst
@@ -1,0 +1,40 @@
+``mybinder.org`` status and reliability
+=======================================
+
+This page serves as a source of information for general Binder status
+updates, building/launching statistics, and reliability metrics.
+
+Site Reliability Goals
+----------------------
+
+``mybinder.org`` is a free service running on open-source software. It should
+be treated as "beta" technology. As such, the Binder team chooses reliability
+goals that are generally less than the gold-standard in industry.
+
+We are still working on defining what the exact goals for uptime and reliability
+should be. Currently we shoot for 'best effort'.
+
+.. note::
+
+   The ``mybinder.org`` team can always use more help in maintaining the
+   BinderHub deployment that runs this site. If you're interested in getting
+   involved, or have any thoughts or suggestions,
+   please reach out to us on `our Gitter channel <https://gitter.im/jupyterhub/binder>`_.
+
+Site metrics
+------------
+
+Below are two key reliability metrics that give an idea for the health of
+the ``mybinder.org`` deployment. Note that you can find many more metrics about
+the ``mybinder.org`` deployment at `grafana.mybinder.org <https://grafana.mybinder.org>`_.
+
+
+.. raw:: html
+
+   <iframe src="https://grafana.mybinder.org/dashboard-solo/db/service-level-objectives?orgId=1&panelId=1&from=1517940977444&to=1518545777444&theme=light" style="width: 100%; height: 200px" frameborder="0"></iframe>
+   <br />
+   <br />
+
+.. raw:: html
+
+   <iframe src="https://grafana.mybinder.org/dashboard-solo/db/service-level-objectives?orgId=1&panelId=2&from=1517940892627&to=1518545692627&theme=light" style="width: 100%; height: 200px" frameborder="0"></iframe>

--- a/doc/reliability.rst
+++ b/doc/reliability.rst
@@ -7,12 +7,14 @@ updates, building/launching statistics, and reliability metrics.
 Site Reliability Goals
 ----------------------
 
-``mybinder.org`` is a free service running on open-source software. It should
-be treated as "beta" technology. As such, the Binder team chooses reliability
-goals that are generally less than the gold-standard in industry.
+As ``mybinder.org`` is a research pilot project, the main goal for the project
+is to understand usage patterns and workloads for future project evolution.
+While we strive for site reliability and availability, we want our users to
+understand the intent of this service is research and we offer no guarantees
+of its performance in mission critical uses.
 
 We are still working on defining what the exact goals for uptime and reliability
-should be. Currently we shoot for 'best effort'.
+should be.
 
 .. note::
 


### PR DESCRIPTION
I took a stab at making a "reliability / metrics" page. It still needs some content, but the basic structure is there. Here's a live version:

http://predictablynoisy.com/binder/reliability.html

It basically does two things:

1. Give some indication of what users should expect for `mybinder.org`. I haven't put anything concrete here yet since we should decide that collectively.
2. Embed two of the grafana plots that I made for the SLO dashboard.

Hopefully this is a start...would love to hear what people think!