### PR TITLE
Add section on binderhub deployments in the wild

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -63,10 +63,10 @@ as resources for more information.
    reliability
    more-info
 
-Binderhub in the wild
----------------------
+Binder in the wild
+------------------
 
-This is a list of private or public `Binderhub <http://binderhub.readthedocs.io>`_
+This is a list of private or public `Binder <http://binderhub.readthedocs.io>`_
 instances. If you would like to list yours here `open an issue <https://github.com/jupyterhub/binder/issues/new>`
 and let us know.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -62,3 +62,15 @@ as resources for more information.
    faq
    reliability
    more-info
+
+Binderhub in the wild
+---------------------
+
+This is a list of private or public `Binderhub <http://binderhub.readthedocs.io>`_
+instances. If you would like to list yours here `open an issue <https://github.com/jupyterhub/binder/issues/new>`
+and let us know.
+
+A list like this helps the project prioritize work based on actual usage patterns
+and gives us (and our funders) concrete evidence of adoption.
+
+* Be the first one! `Open an issue <https://github.com/jupyterhub/binder/issues/new>`.


### PR DESCRIPTION
Fixes #75 

This adds a short section encouraging people to share with us their public and private binderhub deployments.

I think while it is short (read: empty) we can feature it prominently on the front page of the docs, once it starts having content I expect it to become a subpage.

Is there a sentence we can add that gives people a reason to list their service here? I think by listing yourself here you get street cred/bragging rights, "we are early adopters", more traffic (but struggling to make a good sentence out of those ideas).