### PR TITLE
Adding repo links for RMarkdown and Jupyter+R

### DIFF
--- a/doc/sample_repos.md
+++ b/doc/sample_repos.md
@@ -210,9 +210,9 @@ index.ipynb
 ---------
 ## Specifying an R environment with a runtime.txt file
 
-Jupyter+R: [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/v2/gh/binder-examples/r/master?filepath=index.ipynb)
+Jupyter+R: [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/v2/gh/binder-examples/r/master?filepath=index.ipynb) | [repo link](https://github.com/binder-examples/r)
 
-RStudio: [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/v2/gh/binder-examples/r/master?urlpath=rstudio)
+RStudio: [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/v2/gh/binder-examples/r/master?urlpath=rstudio) | [repo link](https://github.com/binder-examples/r)
 
 Binder supports using R + RStudio, with libraries pinned to a specific 
 snapshot on [MRAN](https://mran.microsoft.com/documents/rro/reproducibility).


### PR DESCRIPTION
This updates the documentation for binder examples to include repo links for the R examples.