### PR TITLE
updating repo2docker config file link

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -173,7 +173,7 @@ texinfo_documents = [
 # -- Scripts --------------------------------------------------------------
 
 # Grab the latest version of the configuration file examples.
-url_config = "https://raw.githubusercontent.com/jupyter/repo2docker/master/docs/source/config_files.txt"
+url_config = "https://raw.githubusercontent.com/jupyter/repo2docker/master/docs/source/config_files.rst"
 resp = requests.get(url_config)
 with open('./config_files.txt', 'w') as ff:
     ff.write(resp.text)


### PR DESCRIPTION
A recent PR broke the importing that we were doing in the Binder docs for the "configuration files" page. Since then, the [preparing a repo for binder](https://mybinder.readthedocs.io/en/latest/using.html#preparing-a-repository-for-binder) page has been serving a 404 error.

This PR updates the link so that it works again.

Done in conjunction with https://github.com/jupyter/repo2docker/pull/370