### PR TITLE
adding an about page

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -1,0 +1,47 @@
+.. _about:
+
+======================
+About ``mybinder.org``
+======================
+
+This page explains some of the teams and organizations behind mybinder.org.
+
+What technology runs mybinder.org?
+==================================
+
+The technology behind mybinder.org is primarily composed of three open-source projects:
+
+* `JupyterHub <https://z2jh.jupyter.org>`_, which manages cloud infrastructure for user instances
+* `repo2docker <repo2docker.readthedocs.io>`_, which builds Docker images from GitHub repositories
+* `BinderHub <binderhub.readthedocs.io>`_, which orchestrates the above two projects and
+  provides the Binder interface.
+
+Each of these are open and inclusively-governed projects. Currently, these are all officially
+hosted as a part of Project Jupyter, an open project that creates open tools for data science
+infrastructure and interactive computation. The mybinder.org team is
+heavily involved in each, though mybinder.org does not need to have a controlling
+stake in any of them.
+
+Who runs mybinder.org?
+======================
+
+mybinder.org is a single deployment of the BinderHub technology. It is run as a free, public
+service to the scientific and educational community. It also serves as a way for the Binder
+project to test the "cutting edge" of Binder and demonstrate the technology.
+
+Currently, the mybinder.org team is comprised of the `Binder Project team <https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team>`_.
+However, as time moves on we expect that these two teams will start to diverge as more
+institutions deploy BinderHub for their own purposes, and want to help govern the direction
+of the project.
+
+What kind of an organization is the mybinder.org team?
+======================================================
+
+The mybinder.org team is currently housed as a member of Project Jupyter, which is
+itself housed under NumFocus, a 501c3 non-profit. 
+
+Who pays for mybinder.org?
+==========================
+
+Currently, the BinderHub deployment at mybinder.org is paid for with a
+`grant from the Moore Foundation <https://figshare.com/s/e9d0ad7bdc4e405cccfa>`_.

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -4,7 +4,30 @@
 About ``mybinder.org``
 ======================
 
+mybinder.org is a deployment of the BinderHub technology. It is run as a public
+service for those who'd like to share their interactive repositories publicly.
+It is used by the Binder project to demonstrate the "cutting edge" of its technology.
+
 This page explains some of the teams and organizations behind mybinder.org.
+
+What kind of an organization is the Binder Project?
+===================================================
+
+The Binder Project is currently housed as a member of Project Jupyter, which is
+itself housed under NumFocus, a 501c3 non-profit. 
+
+Who runs mybinder.org?
+======================
+
+Currently, mybinder.org is run by the `Binder team <https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team>`_,
+which are the core team members of the Binder Project.
+
+Who pays for mybinder.org?
+==========================
+
+Currently, the BinderHub deployment at mybinder.org is funded with 
+grants from the `Moore Foundation <https://figshare.com/s/e9d0ad7bdc4e405cccfa>`_.
+and the `Google Cloud Platform <https://cloud.google.com/>`_.
 
 What technology runs mybinder.org?
 ==================================
@@ -17,31 +40,7 @@ The technology behind mybinder.org is primarily composed of three open-source pr
   provides the Binder interface.
 
 Each of these are open and inclusively-governed projects. Currently, these are all officially
-hosted as a part of Project Jupyter, an open project that creates open tools for data science
-infrastructure and interactive computation. The mybinder.org team is
-heavily involved in each, though mybinder.org does not need to have a controlling
-stake in any of them.
-
-Who runs mybinder.org?
-======================
-
-mybinder.org is a single deployment of the BinderHub technology. It is run as a free, public
-service to the scientific and educational community. It also serves as a way for the Binder
-project to test the "cutting edge" of Binder and demonstrate the technology.
-
-Currently, the mybinder.org team is comprised of the `Binder Project team <https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team>`_.
-However, as time moves on we expect that these two teams will start to diverge as more
-institutions deploy BinderHub for their own purposes, and want to help govern the direction
-of the project.
-
-What kind of an organization is the mybinder.org team?
-======================================================
-
-The mybinder.org team is currently housed as a member of Project Jupyter, which is
-itself housed under NumFocus, a 501c3 non-profit. 
-
-Who pays for mybinder.org?
-==========================
-
-Currently, the BinderHub deployment at mybinder.org is paid for with a
-`grant from the Moore Foundation <https://figshare.com/s/e9d0ad7bdc4e405cccfa>`_.
+hosted as a part of `Project Jupyter <https://github.com/jupyter/governance>`_,
+an open project that creates open tools for data science
+infrastructure and interactive computation. The Binder team is
+heavily involved in each.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -19,6 +19,8 @@ files) into computational environments (a Docker image) and serve this
 environment through the cloud. The underlying technology that manages this
 process is called `BinderHub`_.
 
+For more information, check out :ref:`about`.
+
 What is BinderHub?
 ------------------
 
@@ -37,6 +39,8 @@ of the BinderHub technology, though it is by no means the only BinderHub
 in existence. If you're interested in deploying your own BinderHub for your
 own uses, please see the `BinderHub documentation <BinderHub_>`_
 and don't hesitate to reach out to the `Binder community <https://gitter.im/jupyterhub/binder>`_.
+
+For more information, check out :ref:`about`.
 
 Is ``mybinder.org`` free to use?
 --------------------------------
@@ -58,8 +62,9 @@ repository. In addition, you can explore these costs with the binder link below!
 How can ``mybinder.org`` be free to use?
 ----------------------------------------
 
-The Binder project has a `grant from the Moore Foundation <https://figshare.com/s/e9d0ad7bdc4e405cccfa>`_
-to sustain the cloud resources running ``mybinder.org``. In the future we hope to see more
+See :ref:`about` for more information on the mybinder.org team and who provides
+the resources to pay for the service. Generally, mybinder.org is run with modest resources
+provided to users in order to keep costs down. In the future we hope to see more
 public BinderHub services running that can form a collection of community
 resources for interactive cloud computing.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,6 +10,8 @@ Binder Documentation
 and used by many remote users. It is powered by `BinderHub <https://github.com/jupyterhub/binderhub>`_,
 which is an open-source tool that deploys the Binder service in the cloud.
 One-such deployment lives here, at `mybinder.org <https://mybinder.org>`_, and is free to use.
+For more information about the mybinder.org deployment and the team that runs it, see
+:ref:`about`.
 
 This documentation provides information for those who
 wish to use a pre-existing BinderHub deployment such as `mybinder.org <https://mybinder.org>`_.
@@ -81,5 +83,6 @@ as resources for more information.
    user-guidelines
    faq
    status
+   about
    reliability
    more-info


### PR DESCRIPTION
We've had several instances now where there was confusion because it's unclear exactly who runs "mybinder.org", what's their relationship to Jupyter, to BinderHub, etc. This is an attempt to disambiguate this a bit, without making any strong statement about team governance since that'll likely be a longer process.

Would love feedback, thoughts, etc!

What do folks think about directing either `about.mybinder.org` or `mybinder.org/about` to this page?