### PR TITLE
adding citation instructions

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -229,4 +229,9 @@ for instructions on how to deploy your own BinderHub, and the
 `Zero to JupyterHub <https://zero-to-jupyterhub.readthedocs.io/en/latest/user-experience.html#set-user-memory-and-cpu-guarantees-limits>`_
 documentation for how to customize the user environment.
 
+How can I cite Binder?
+----------------------
+
+For information on how to cite Binder, see :ref:`citing`.
+
 .. _BinderHub: https://binderhub.readthedocs.io/en/latest

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -83,3 +83,19 @@ as resources for more information.
    status
    reliability
    more-info
+
+.. _citing:
+
+Citing Binder
+=============
+
+If you publish work that uses Binder, please consider citing the
+`Binder paper from the 2018 SciPy proceedings <http://conference.scipy.org/proceedings/scipy2018/project_jupyter.html>`_!
+
+Here is a citation that you can use:
+
+.. code-block:: none
+
+   Jupyter et al., "Binder 2.0 - Reproducible, Interactive, Sharable
+   Environments for Science at Scale." Proceedings of the 17th Python
+   in Science Conference. 2018. 10.25080/Majora-4af1f417-011


### PR DESCRIPTION
@dhuppenkothen made a good point that it's unclear how to cite Binder. This is one attempt at making it easier to find this information. Do folks think that this is a good place for this info to exist? Maybe we should also put it in the "about" page PR that @betatim opened?