### PR TITLE
bringing in new howto pages

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -170,10 +170,13 @@ with open('./config_files.rst', 'w') as ff:
 
 # Grab the latest version of the configuration file examples
 print('Updating latest howto pages from repo2docker...')
-howto_imports = ["languages.rst", "user_interface.rst"]
-url_howto = "https://raw.githubusercontent.com/jupyter/repo2docker/master/docs/source/howto/{}"
+howto_imports = ["jupyter/repo2docker/master/docs/source/howto/languages.rst",
+                 "jupyter/repo2docker/master/docs/source/howto/user_interface.rst",
+                 "jupyter/repo2docker/master/docs/source/howto/lab_workspaces.rst",
+                 "jupyterhub/mybinder.org-deploy/master/docs/source/analytics/events-archive.rst"]
+url_base = "https://raw.githubusercontent.com/{}"
 for rst_file in howto_imports:
-    this_url = url_howto.format(rst_file)
+    this_url = url_base.format(rst_file)
     resp = requests.get(this_url)
     dir_howto = os.path.join(os.path.dirname(__file__), 'howto')
     if not os.path.exists(dir_howto):

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -42,7 +42,7 @@ The following sections cover the basics of how to use a Binder service.
 
 .. toctree::
    :caption: How to...
-   :maxdepth: 1
+   :maxdepth: 2
 
    howto/languages
    howto/user_interface


### PR DESCRIPTION
This brings in new content/pages from https://github.com/jupyter/repo2docker/pull/568 into the Binder docs. It also adds @yuvipanda 's page about Binder analytics from the mybinder.org SRE repository. We shouldn't merge this until at least https://github.com/jupyter/repo2docker/pull/568 is merged