### PR TITLE
Edit on GitHub

### DIFF
--- a/doc/_templates/edit_on_github.html
+++ b/doc/_templates/edit_on_github.html
@@ -1,0 +1,12 @@
+<div role="note" aria-label="source link">
+    {% if sourcename is defined %}
+    {% set src = sourcename.split('.') %}
+    <h3>This Page</h3>
+    <ul class="this-page-menu">
+        <li>
+            <a href="https://github.com/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}/{{ doc_path }}/{{ pagename }}.{{ src[-2] }}">Edit this page</a>
+        </li>
+    </ul>
+     {% endif %}
+</div>
+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,7 +68,9 @@ language = None
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
-html_sidebars = { '**': ['globaltoc.html', 'relations.html', 'sourcelink.html', 'searchbox.html'] }
+html_sidebars = { '**': [
+    'globaltoc.html', 'relations.html',  'edit_on_github.html', 'searchbox.html',
+]}
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
@@ -94,7 +96,18 @@ html_theme_path = [alabaster_jupyterhub.get_html_theme_path()]
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+# html_theme_options = {
+#     'github_user': 'jupyterhub',
+#     'github_repo': 'binder',
+# }
+
+html_context = {
+    "github_user": "jupyterhub",
+    "github_repo": "binder",
+    "github_version": "master",
+    "doc_path": "doc",
+    "source_suffix": source_suffix,
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -96,7 +96,7 @@ html_theme_path = [alabaster_jupyterhub.get_html_theme_path()]
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = { }
+# html_theme_options = {}
 
 html_context = {
     "github_user": "jupyterhub",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -96,10 +96,7 @@ html_theme_path = [alabaster_jupyterhub.get_html_theme_path()]
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {
-#     'github_user': 'jupyterhub',
-#     'github_repo': 'binder',
-# }
+# html_theme_options = { }
 
 html_context = {
     "github_user": "jupyterhub",


### PR DESCRIPTION
- replace the "View page source" with "Edit this page" which links to the edit-url of the page on GitHub
- question: do we still want the "View page source" ? 
    (my 2 cents: it is redundant, but others may think differently??) 
- closes #146 

![monosnap 2019-01-31 14-58-20](https://user-images.githubusercontent.com/6361812/52091360-03611a80-2569-11e9-95ed-085ae9fb90cc.png)


![image](https://user-images.githubusercontent.com/6361812/52091398-2390d980-2569-11e9-9e92-86364b104194.png)
