### PR TITLE
removing docs env.yml and switching rtd to reqs.txt

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,8 +1,0 @@
-name: mybinder
-channels:
-  - conda-forge
-dependencies:
-  - python=3.5
-  - sphinx>=1.3.6,!=1.5.4
-  - pip:
-    - -r doc-requirements.txt

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,6 @@
-name: mybinder 
+name: mybinder
 type: sphinx
-conda:
-    file: doc/environment.yml
+requirements_file: doc/doc-requirements.txt
 python:
   version: 3
 formats:


### PR DESCRIPTION
This tries to simplify our docs requirements (we were using an environment.yml file, but only installing things w/ pip, so this just uses pip)