### PR TITLE
Dockerfile: ARGs with defaults for repo2docker

### DIFF
--- a/doc/tutorials/dockerfile.rst
+++ b/doc/tutorials/dockerfile.rst
@@ -124,8 +124,10 @@ For a Dockerfile to work on Binder, it must meet the following requirements:
 
    .. code-block:: Dockerfile
 
-      ENV NB_USER jovyan
-      ENV NB_UID 1000
+      ARG NB_USER=jovyan
+      ARG NB_UID=1000
+      ENV USER ${NB_USER}
+      ENV NB_UID ${NB_UID}
       ENV HOME /home/${NB_USER}
 
       RUN adduser --disabled-password \


### PR DESCRIPTION
repo2docker let's you customize NB_USER and NB_UID build arguments. Without that change to consume them they're ignored. The defaults are the usual values and hence that Dockerfile will still work without explicitly setting build variables.