### PR TITLE
add example repository (tensorboard)

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -61,3 +61,12 @@ Scientific research and reproducibility
     * `github <https://github.com/costrouc/nix-binder-example>`_
     * .. image:: https://mybinder.org/badge_logo.svg
          :target: https://mybinder.org/v2/gh/costrouc/nix-binder-example/master
+         
+         
+Machine learning and deep learning
+==================================
+
+* Monitoring training of deep neural networks using **tensorboard** on binder.
+    * `github <https://github.com/btel/binder-tensorboard>`_
+    * .. image:: https://mybinder.org/badge_logo.svg
+         :target: https://mybinder.org/v2/gh/btel/binder-tensorboard/master?urlpath=%2fproxy%2f6006%2f


### PR DESCRIPTION
This PR adds an example to the community section. The interest of the example is that:

* it shows how to use tensorboard on binder or other jupyter-based environments. In such environments, tensorboard can not be often used because it creates a webapp that listens on a port that is not visible to the outside world,

* it uses the jupyter-proxy-server extension that solves the above problem

* it launches the tensorboard in the background, so that it is immediately available after launching the nootebook.

The examples lives in my GH account so far, but I am happy to move it elsewhere (binder-examples) as needed.

See also https://github.com/jupyterhub/jupyter-server-proxy/issues/41 for background information.