### PR TITLE
Fix typos in R:libraries should be called packages

### DIFF
--- a/doc/sample_repos.md
+++ b/doc/sample_repos.md
@@ -158,7 +158,7 @@ RStudio: [![Binder](http://mybinder.org/badge_logo.svg)](http://mybinder.org/v2/
 
 RShiny: [![Binder](http://mybinder.org/badge_logo.svg)](http://mybinder.org/v2/gh/binder-examples/r/master?urlpath=shiny/bus-dashboard/)
 
-Binder supports using R and RStudio, with libraries pinned to a specific
+Binder supports using R and RStudio, with packages pinned to a specific
 snapshot on [MRAN](https://mran.microsoft.com/documents/rro/reproducibility).
 
 You need to have a `runtime.txt` file that is formatted like:
@@ -168,10 +168,10 @@ r-<YYYY>-<MM>-<DD>
 ```
 
 where YYYY-MM-DD is a snapshot at MRAN that will be used for installing
-libraries.
+packages.
 
 You can also have an `install.R` file that will be executed during build,
-and can be used to install libraries.
+and can be used to install packages.
 
 Both [RStudio](https://www.rstudio.com/) and [IRKernel](https://irkernel.github.io/)
 are installed by default, so you can use either the Jupyter notebook interface or
@@ -199,7 +199,7 @@ Jupyter+R: [![Binder](http://mybinder.org/badge_logo.svg)](http://mybinder.org/v
 RStudio: [![Binder](http://mybinder.org/badge_logo.svg)](http://mybinder.org/v2/gh/binder-examples/binder-r-description/master?urlpath=rstudio)
 
 
-Binder supports using R and RStudio, with libraries pinned to a specific
+Binder supports using R and RStudio, with packages pinned to a specific
 snapshot on [MRAN](https://mran.microsoft.com/documents/rro/reproducibility).
 
 If you specify a `runtime.txt` file that is formatted like:


### PR DESCRIPTION
In  R terminology, packages are installed into a library.