### PR TITLE
[DOC] Fix typo in Dockerfile tutorial

### DIFF
--- a/doc/tutorials/dockerfile.rst
+++ b/doc/tutorials/dockerfile.rst
@@ -188,5 +188,5 @@ of another image. This ensures that you will continue building off of
 the same image even if the image is updated to a new version.
 
 Next, make sure that all packages installed with your Dockerfile
-are pinned to specific versions. You should do this with the the image you are
+are pinned to specific versions. You should do this with the image you are
 sourcing as well.


### PR DESCRIPTION
Fix mini typo in Dockerfile tutorial: removed extra "the" (before 2x)