### PR TITLE
binder-badge can use new pull_request_target

### DIFF
--- a/doc/howto/binder-badge.yaml
+++ b/doc/howto/binder-badge.yaml
@@ -1,22 +1,25 @@
-#./github/workflows/binder-badge.yaml
+#./.github/workflows/binder-badge.yaml
 name: Binder Badge
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   binder:
     runs-on: ubuntu-latest
-    steps: 
+    steps:
     - name: comment on PR with Binder link
       uses: actions/github-script@v1
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          var BRANCH_NAME = process.env.BRANCH_NAME;
+          var PR_HEAD_USER = process.env.GITHUB_ACTOR;
+          var PR_HEAD_REPO = process.env.PR_HEAD_REPO;
+          var PR_HEAD_SHA = process.env.PR_HEAD_SHA;
           github.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${context.repo.owner}/${context.repo.repo}/${BRANCH_NAME}) :point_left: Launch a binder notebook on this branch`
-          }) 
+            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USER}/${PR_HEAD_REPO}/${PR_HEAD_SHA}) :point_left: Launch a binder notebook on this branch for commit ${PR_HEAD_SHA}`
+          })
       env:
-        BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.name }}

--- a/doc/howto/gh-actions-badges.md
+++ b/doc/howto/gh-actions-badges.md
@@ -7,13 +7,9 @@ To enable GitHub Actions, you must place .yaml files that define your GitHub Act
 
 ## Example 1: Comment on pull request with a binder badge
 
-```{note}
-This example will not work on pull requests from forks.  This is to protect repositories from malicious actors.  To trigger a GitHub Action with sufficient permissions to comment on a pull request from a fork, you must trigger the action via another event, such as a comment or a label.  This is demonstrated in Example 2 below.
-```
-
 The below action uses the [github/script](https://github.com/actions/github-script) Action to call the [GitHub API](https://docs.github.com/en/rest/reference/issues#comments) for the purposes of making a comment on a PR that looks like this:
 
-> ![Binder](https://mybinder.org/badge_logo.svg) 👈 Launch a binder notebook on this branch
+> ![Binder](https://mybinder.org/badge_logo.svg) 👈 Launch a binder notebook on this branch for commit xxxxxxx
 
 Download the below file: {download}`binder-badge.yaml <./binder-badge.yaml>`
 


### PR DESCRIPTION
binder-badge.yml will now work with pull requests from forks, using the new `pull_request_target`.
the action is also changed to use the commit sha instead of the branch name- since it's automatically run after every push to a PR this probably makes more sense than repeatedly posting a badge with the same branch name.