### PR TITLE
Add a link to Temporary Banning section to issues

### DIFF
--- a/doc/user-guidelines.rst
+++ b/doc/user-guidelines.rst
@@ -15,6 +15,10 @@ result in temporary banning include:
 * Sessions that routinely use a large amount of CPU.
 * Sessions that attempt to perform a lot of outgoing networking traffic.
 
+If you are concerned that your repository may be liable for banning, please feel free to
+`open an issue <https://github.com/jupyterhub/mybinder.org-deploy/issues/new?labels=question&template=ban_check.md>`_
+and a member of the team can help you.
+
 The ``mybinder.org`` team uses the following workflow in discussing / deciding
 when to temporarily ban a repository:
 


### PR DESCRIPTION
This PR adds a link to the Temporary Banning section of the docs to an issue template where folks can get their repo checked if they're concerned about banning.

🚨 The link won't work until https://github.com/jupyterhub/mybinder.org-deploy/pull/1570 is merged 🚨 