### PR TITLE
🐛 FIX: documentation bug in pydata theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -125,7 +125,7 @@ rediraffe_redirects = {
 myst_admonition_enable = True
 myst_deflist_enable = True
 
-panels_add_boostrap_css = False
+panels_add_bootstrap_css = False
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -6,5 +6,5 @@ jupyterhub
 memory_profiler
 pytest
 PyGitHub
-pydata_sphinx_theme
+git+https://github.com/pandas-dev/pydata-sphinx-theme
 sphinxext-rediraffe


### PR DESCRIPTION
We found a bug when #213 was merged! So I fixed it in the pydata theme master and now am pinning our version to pydata master until a new version is released 👍. I don't think this should be a big deal since it'll *only* affect doc builds.

(the reason that the bug didn't show up before was because it only appears on `singlehtml` builds and I guess RTD builds don't use that builder when they do PR previews)