### PR TITLE
Point binder to the branch

### DIFF
--- a/doc/howto/binder-badge.yaml
+++ b/doc/howto/binder-badge.yaml
@@ -12,13 +12,13 @@ jobs:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           var PR_HEAD_USERREPO = process.env.PR_HEAD_USERREPO;
-          var PR_HEAD_SHA = process.env.PR_HEAD_SHA;
+          var PR_HEAD_REF = process.env.PR_HEAD_REF;
           github.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_SHA}) :point_left: Launch a binder notebook on this branch for commit ${PR_HEAD_SHA}`
+            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}) :point_left: Launch a binder notebook on branch _${PR_HEAD_REF}_`
           })
       env:
-        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         PR_HEAD_USERREPO: ${{ github.event.pull_request.head.repo.full_name }}

--- a/doc/howto/gh-actions-badges.md
+++ b/doc/howto/gh-actions-badges.md
@@ -9,7 +9,7 @@ To enable GitHub Actions, you must place .yaml files that define your GitHub Act
 
 The below action uses the [github/script](https://github.com/actions/github-script) Action to call the [GitHub API](https://docs.github.com/en/rest/reference/issues#comments) for the purposes of making a comment on a PR that looks like this:
 
-> ![Binder](https://mybinder.org/badge_logo.svg) 👈 Launch a binder notebook on this branch for commit xxxxxxx
+> ![Binder](https://mybinder.org/badge_logo.svg) 👈 Launch a binder notebook on branch _xxxxxxx_
 
 Download the below file: {download}`binder-badge.yaml <./binder-badge.yaml>`
 


### PR DESCRIPTION
I think it will make more sense to spin binder on the PR branch than on a PR commit.