### PR TITLE
Add binder badge only on PR opened event

### DIFF
--- a/doc/howto/binder-badge.yaml
+++ b/doc/howto/binder-badge.yaml
@@ -1,6 +1,8 @@
 #./.github/workflows/binder-badge.yaml
 name: Binder Badge
-on: [pull_request_target]
+on: 
+  pull_request_target:
+    types: [opened]
 
 jobs:
   binder:
@@ -17,7 +19,7 @@ jobs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}) :point_left: Launch a binder notebook on branch _${PR_HEAD_REF}_`
+            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}) :point_left: Launch a binder notebook on branch _${PR_HEAD_USERREPO}/${PR_HEAD_REF}_`
           })
       env:
         PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
Follow-up of #217 

As suggested by @consideRatio, this reduce this action to the open event on a PR. I also add the PR origin repo name in the comment to clarify it when the PR comes from a fork.