### PR TITLE
Events with mybinder should be fine for up to 100 users

### DIFF
--- a/doc/about/user-guidelines.md
+++ b/doc/about/user-guidelines.md
@@ -34,7 +34,7 @@ how to un-ban the repository.
 
 ## Running events with `mybinder.org`
 
-If you'd like to run an event with `mybinder.org` and expect more than 50 users
+If you'd like to run an event with `mybinder.org` and expect more than 100 users
 to join at once, please [request an increase in quota for your repository](https://github.com/jupyterhub/mybinder.org-deploy/issues/new?labels=impact&template=request_resources.md).
 
 The Binder Team occasionally increases the number of sessions that can run for a single repository if it is being used for purposes that align with the mission of the Binder Project. However, there is no guarantee that this will be done for your event.


### PR DESCRIPTION
Change recommendation to open an issue if more than 100 users are expected (previously 50), this matches https://github.com/jupyterhub/mybinder.org-deploy/blob/0aa006b74d3ed1a28a54bcd07c6d17e33fba209a/mybinder/values.yaml#L84 and https://github.com/jupyterhub/binder/blob/master/doc/about/user-guidelines.md#maximum-concurrent-users-for-a-repository

See https://github.com/jupyterhub/mybinder.org-deploy/issues/1701#issuecomment-729092949