### PR TITLE
Update to actions/github-script@v3

### DIFF
--- a/doc/howto/binder-badge-permissions.yaml
+++ b/doc/howto/binder-badge-permissions.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
     - name: comment on PR with Binder link
-      uses: actions/github-script@v1
+      uses: actions/github-script@v3
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |

--- a/doc/howto/binder-badge.yaml
+++ b/doc/howto/binder-badge.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: comment on PR with Binder link
-      uses: actions/github-script@v1
+      uses: actions/github-script@v3
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |

--- a/doc/howto/chatops-binder.yaml
+++ b/doc/howto/chatops-binder.yaml
@@ -12,7 +12,7 @@ jobs:
       #  (1) Get the branch name of the PR that has been commented on with "/binder" 
       #  (2) make a comment on the PR with the binder badge
     - name: comment on PR with Binder link
-      uses: actions/github-script@v1
+      uses: actions/github-script@v3
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |


### PR DESCRIPTION
Update the Binder badge GitHub workflow snippets to `actions/github-script@v3`, so folks copy pasting the snippets will get to use the latest version of the action.

https://mybinder.readthedocs.io/en/latest/howto/gh-actions-badges.html