### PR TITLE
binder-badge workflow needs permissions.pull-requests:write

### DIFF
--- a/doc/howto/binder-badge-permissions.yaml
+++ b/doc/howto/binder-badge-permissions.yaml
@@ -12,6 +12,8 @@ jobs:
         (github.event.issue.author_association == 'MEMBER')
       )
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps: 
     - name: comment on PR with Binder link
       uses: actions/github-script@v3

--- a/doc/howto/binder-badge.yaml
+++ b/doc/howto/binder-badge.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   binder:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - name: comment on PR with Binder link
       uses: actions/github-script@v3


### PR DESCRIPTION
If you're restricted your `GITHUB_TOKEN` to default to read-only you'll need extra permissions on the binder badge workflows. If you haven't restricted `GITHUB_TOKEN` this has no effect so might as well always include it.

- I've verified the `binder-badge.yaml` change in https://github.com/jupyterhub/jupyter-remote-desktop-proxy/commit/5c46d99aa244b3a4e9a8df72e9703d4695900170 https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/6#issuecomment-825526604
- `binder-badge-permissions.yaml` looks similar enough that it should work without testing

I didn't update `chatops-binder.yaml` because I don't have somewhere to test it- does it need `issues`, `pull-requests`, or both?