### PR TITLE
add hint about broken URLs when jupyterlab is missing

### DIFF
--- a/doc/tutorials/dockerfile.md
+++ b/doc/tutorials/dockerfile.md
@@ -87,6 +87,11 @@ For a Dockerfile to work on Binder, it must meet the following requirements:
    RUN pip install --no-cache-dir notebook
    ```
 
+   Note that if you are not installing {}`jupyterlab` in addition to the classic {}`notebook`,
+   you'll need to manually change your mybinder.org URLs from `/lab` to `/tree` as described
+   [here](<https://mybinder.readthedocs.io/en/latest/howto/user_interface.html#jupyterlab>).
+   Otherwise, you might get a "404: Not Found" error when launching your project on binder.
+
    If you would like to use the repository with an authenticated Binder you
    should also install the `jupyterhub` package.
 

--- a/doc/tutorials/dockerfile.md
+++ b/doc/tutorials/dockerfile.md
@@ -87,10 +87,10 @@ For a Dockerfile to work on Binder, it must meet the following requirements:
    RUN pip install --no-cache-dir notebook
    ```
 
-   Note that if you are not installing {}`jupyterlab` in addition to the classic {}`notebook`,
-   you'll need to manually change your mybinder.org URLs from `/lab` to `/tree` as described
-   [here](<https://mybinder.readthedocs.io/en/latest/howto/user_interface.html#jupyterlab>).
-   Otherwise, you might get a "404: Not Found" error when launching your project on binder.
+   :::{note}
+   If you install [the classic notebook interface](https://jupyter-notebook.readthedocs.io/en/stable/) but not [JupyterLab](https://jupyterlab.readthedocs.io/), you must manually change your mybinder.org URLs from `/lab` to `/tree` as described [in the user interface documentation](<https://mybinder.readthedocs.io/en/latest/howto/user_interface.html#jupyterlab>).
+   Otherwise, you might get a `404: Not Found` error when launching your project on binder.
+   :::
 
    If you would like to use the repository with an authenticated Binder you
    should also install the `jupyterhub` package.


### PR DESCRIPTION
see https://github.com/jupyterhub/binder/issues/240